### PR TITLE
#18 re-enable "ignore unknow property" for Eval DTO

### DIFF
--- a/src/main/java/fr/talentRate/dto/EvalDTO.java
+++ b/src/main/java/fr/talentRate/dto/EvalDTO.java
@@ -2,6 +2,7 @@ package fr.talentRate.dto;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
@@ -10,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  *
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-//@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EvalDTO {
     /** Default Evaluation size WITHOUT student size.*/
     protected static final int DEFAULT_EVAL_CHAR_SIZE = 256;


### PR DESCRIPTION
permet d’afficher les données dans l'Elastic Search qui ont des attributs en plus de ceux connus du DTO.